### PR TITLE
[FORK] Triggering Wordpress on Fork to compare with upstream 

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - https://wordpress.org/
-version: 13.3.1
+version: 13.3.2

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -630,4 +630,4 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.
+limitations under the License


### PR DESCRIPTION
We know for sure that the WP workflow + pipeline work properly on upstream
We also know that the Spring Data Workflow doesn't work properly
We want to isolate the problem to Spring Data workflow pipeline, hence I am running the WP pipeline from fork
P.S. The masters are synced this morning. 